### PR TITLE
商品一覧機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
+    @items = Item.includes(:user).order("created_at DESC")
   end
   
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,25 +126,25 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% if @items.count > 0 %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <% @items.each do |item| %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+          <!-- <div class='sold-out'>
+             <span>Sold Out!!</span>
+           </div> -->
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.postage.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +153,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+    <% else %>
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,8 +172,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,8 +127,8 @@
     <ul class='item-lists'>
 
     <% if @items.count > 0 %>
-      <li class='list'>
         <% @items.each do |item| %>
+      <li class='list'>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 


### PR DESCRIPTION
#What
フリマアプリ商品一覧機能の実装
・トップページに商品一覧が表示される
　→ 上から、出品された日時が新しい順に表示されている
　→「画像/価格/商品名」の3つの情報について表示されている
・出品商品がない場合はダミーの画像が表示されるが、出品商品がある場合ダミーは表示されない

＃Why
フリマアプリサイトを訪れた人が出品商品を閲覧できるようにするため。

##トップページ画像
商品がある時
https://gyazo.com/476f8d0fe16a7efcf9389b1ba15dabf4
商品がない時
https://gyazo.com/46a2f0279ae4407af8a31a2954fb1190